### PR TITLE
chore: Set up cloud dev environment (AGENTS.md)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,49 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+`maxminddb-wasm` is a Rust → WebAssembly library (compiled with `wasm-bindgen`) that
+exposes MaxMind GeoIP database lookups to JavaScript/TypeScript. There is **no
+long‑running service**; the "applications" are the generated WASM bindings and the
+per‑platform test suites under `tests/*`.
+
+### Toolchain notes (non‑obvious)
+
+- The Rust toolchain is **nightly** and the `wasm32-unknown-unknown` target is pinned
+  by `rust-toolchain.toml` (rustup adds the target automatically).
+- The build calls the `wasm-bindgen` CLI directly. Its version **must match** the
+  `wasm-bindgen` crate version in `Cargo.lock` (currently `0.2.105`); a mismatch makes
+  `pnpm build` fail with a schema‑version error. The update script installs the pinned
+  CLI. The root `postinstall` (`tsx cli.ts --install-bindgen`) only installs an
+  unpinned latest CLI when none is on `PATH`, so keep the pinned one installed.
+- `bun` and `deno` are **not system tools**; they are provided as pnpm optional
+  dependencies (see `pnpm.onlyBuiltDependencies`) and are on `PATH` only inside
+  `pnpm run` scripts. `pnpm install` installs them.
+
+### Build / test / run
+
+- Build all JS targets (`node`, `browser`, `bundler`, `node-module`): `pnpm build`
+  (see `package.json` scripts). Output dirs are git‑ignored.
+- Run the standard test matrix: `pnpm test`. This fetches the MaxMind test DB to
+  `tests/.GeoLite2-City-Test.mmdb` on first run (needs network) and then runs the
+  `test:*` scripts: **node, node-module, bun, deno** (all pass).
+- The **browser** and **cloudflare** suites are intentionally prefixed `failing:`
+  (`failing:test:browser`, `failing:test:cf-worker`) so `pnpm test` skips them. The
+  browser suite launches Chromium via Playwright (installed) but currently fails on a
+  `@vitest/browser-playwright/context` package‑export resolution error in the test
+  code; the cloudflare suite does not run locally per the README. Do not treat these
+  as environment gaps.
+- There is **no configured lint step** (repo CI is build + test only); `package.json`
+  has no `lint` script and there is no ESLint config despite CONTRIBUTING mentioning it.
+
+### Quick end‑to‑end sanity check
+
+Import from the built `node-module` output and look up an IP present in the test DB
+(`2a02:d100::0001` resolves to Poland / `Europe/Warsaw`):
+
+```js
+import { readFileSync } from 'node:fs';
+import { Maxmind } from './node-module/index.js';
+const mm = new Maxmind(readFileSync('./tests/.GeoLite2-City-Test.mmdb'));
+console.log(mm.lookup_city('2a02:d100::0001'));
+```


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and verifies the development environment for `maxminddb-wasm` (a Rust → WebAssembly library with per‑platform JS/TS test suites). Adds `AGENTS.md` documenting durable, non‑obvious setup/run notes for future cloud agents. No source code was modified.

## Environment setup

- Installed `wasm-bindgen-cli` pinned to `0.2.105` to match the `wasm-bindgen` crate in `Cargo.lock` (mismatches break the build).
- `pnpm install` provisions all workspace deps, including `bun` and `deno` (pnpm optional deps) and Playwright Chromium.
- Nightly Rust toolchain + `wasm32-unknown-unknown` target come from `rust-toolchain.toml`.
- Update script (runs on VM startup): guard‑install pinned `wasm-bindgen-cli`, then `pnpm install`.

## Verification

| Step | Command | Result |
| --- | --- | --- |
| Build | `pnpm build` | Built `node`, `browser`, `bundler`, `node-module` targets |
| Test — Node (CJS) | `pnpm test` → `test:node` | 2 passed |
| Test — Node (ESM) | `pnpm test` → `test:node-module` | 2 passed |
| Test — Bun | `pnpm test` → `test:bun` | 2 passed |
| Test — Deno | `pnpm test` → `test:deno` | 2 passed |
| Hello world | lookup `2a02:d100::0001` via built `node-module` | Poland / `Europe/Warsaw` |

The `browser` and `cloudflare` suites are intentionally prefixed `failing:` and excluded from `pnpm test` (browser fails on a `@vitest/browser-playwright/context` export‑resolution error in the test code; cloudflare doesn't run locally per README). No lint step is configured in the repo.

## Evidence

Build + test + hello-world lookup output:

[build, test and hello-world lookup output](https://cursor.com/agents/bc-b32ccbf4-6f67-4e9f-bfaf-39adce885a1f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fenv_setup_build_test_helloworld.log)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b32ccbf4-6f67-4e9f-bfaf-39adce885a1f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b32ccbf4-6f67-4e9f-bfaf-39adce885a1f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

