### PR TITLE
fix: skip npm republish of an existing version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,9 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          ref: ${{ inputs.tag || github.ref }}
+          # Use the workflow revision (selected branch on dispatch), not the
+          # release tag. Tag v2.2.0 still points at a commit that always
+          # npm-publishes and cannot skip an already-published version.
       
       - name: Setup and cache dependencies
         uses: ./.github/actions/setup-and-cache

--- a/scripts/npm-publish-status.ts
+++ b/scripts/npm-publish-status.ts
@@ -1,0 +1,23 @@
+/** Reads the version from `npm view <pkg>@<version> version` stdout. */
+export function publishedVersionFromNpmView(stdout: string) {
+	const lines = stdout
+		.trim()
+		.split('\n')
+		.map(line => line.trim())
+		.filter(line => line && !line.startsWith('npm '))
+	return lines.at(-1)
+}
+
+/** Returns whether npm rejected a publish because the version already exists. */
+export function isAlreadyPublishedError(error: unknown) {
+	const text = error instanceof Error ? error.message : String(error)
+	return /cannot publish over|previously published versions|EPUBLISHCONFLICT/i.test(
+		text,
+	)
+}
+
+/** Returns whether this npm CLI version can exchange GitHub Actions OIDC. */
+export function supportsTrustedPublishing(npmVersion: string) {
+	const [major = 0, minor = 0, patch = 0] = npmVersion.split('.').map(Number)
+	return major > 11 || (major === 11 && (minor > 5 || (minor === 5 && patch >= 1)))
+}

--- a/scripts/publish-ci.test.ts
+++ b/scripts/publish-ci.test.ts
@@ -1,0 +1,36 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+	isAlreadyPublishedError,
+	publishedVersionFromNpmView,
+	supportsTrustedPublishing,
+} from './npm-publish-status.ts'
+
+test('publishedVersionFromNpmView reads a clean version', () => {
+	assert.equal(publishedVersionFromNpmView('2.2.0\n'), '2.2.0')
+})
+
+test('publishedVersionFromNpmView ignores npm warning lines', () => {
+	assert.equal(
+		publishedVersionFromNpmView('npm warn Unknown env config "verify-deps-before-run"\n2.2.0\n'),
+		'2.2.0',
+	)
+})
+
+test('isAlreadyPublishedError matches npm republish 403', () => {
+	const error = new Error(
+		'npm error code E403\nnpm error 403 Forbidden - You cannot publish over the previously published versions: 2.2.0',
+	)
+	assert.equal(isAlreadyPublishedError(error), true)
+})
+
+test('isAlreadyPublishedError ignores unrelated failures', () => {
+	assert.equal(isAlreadyPublishedError(new Error('ENEEDAUTH')), false)
+})
+
+test('supportsTrustedPublishing requires npm 11.5.1', () => {
+	assert.equal(supportsTrustedPublishing('10.9.7'), false)
+	assert.equal(supportsTrustedPublishing('11.5.0'), false)
+	assert.equal(supportsTrustedPublishing('11.5.1'), true)
+	assert.equal(supportsTrustedPublishing('11.19.1'), true)
+})

--- a/scripts/publish-ci.ts
+++ b/scripts/publish-ci.ts
@@ -3,6 +3,11 @@
 import { readFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import 'zx/globals'
+import {
+	isAlreadyPublishedError,
+	publishedVersionFromNpmView,
+	supportsTrustedPublishing,
+} from './npm-publish-status.ts'
 
 let version = process.argv[2]
 const flags = new Set(process.argv.slice(3))
@@ -68,7 +73,16 @@ async function publishNpm(
 	if (distTag) {
 		npmArgs.push('--tag', distTag)
 	}
-	await $`npm ${npmArgs}`
+	try {
+		await $`npm ${npmArgs}`
+	}
+	catch (error) {
+		if (isAlreadyPublishedError(error)) {
+			console.log(`npm ${name}@${packageVersion} already published, skipping`)
+			return
+		}
+		throw error
+	}
 }
 
 /** Publishes to JSR using OIDC, or JSR_TOKEN when that secret is set. */
@@ -84,11 +98,8 @@ async function publishJsr() {
 /** Returns whether this version is already on the npm registry. */
 async function isNpmVersionPublished(name: string, packageVersion: string) {
 	const result = await $`npm view ${name}@${packageVersion} version`.nothrow()
-	return result.exitCode === 0 && result.stdout.trim() === packageVersion
-}
-
-/** Returns whether this npm CLI version can exchange GitHub Actions OIDC. */
-function supportsTrustedPublishing(npmVersion: string) {
-	const [major = 0, minor = 0, patch = 0] = npmVersion.split('.').map(Number)
-	return major > 11 || (major === 11 && (minor > 5 || (minor === 5 && patch >= 1)))
+	if (result.exitCode !== 0) {
+		return false
+	}
+	return publishedVersionFromNpmView(result.stdout) === packageVersion
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Retrying Release with tag `v2.2.0` checked out that tag (`2a07b09`), whose publish script always runs `npm publish`. npm 2.2.0 is already on the registry, so the job failed with “cannot publish over the previously published versions” and never reached JSR.

This keeps checkout on the selected branch (so dispatch from `dev` uses the skip logic) and treats an npm republish conflict as a skip.

## Test plan

- [x] `tsx --test scripts/publish-ci.test.ts`
- [x] `tsx scripts/publish-ci.ts v2.2.0 --npm-only` prints already published, skipping
- [ ] Dispatch Release from `dev` with tag `v2.2.0` skips npm and continues to JSR

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e3a09f8e-dce8-48a8-bbcd-2534ae4eaeea?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e3a09f8e-dce8-48a8-bbcd-2534ae4eaeea&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

