### PR TITLE
fix: changelogithub uses the release tag on workflow dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,9 +57,16 @@ jobs:
           path: .
 
       - name: Changelog
-        run: pnpm dlx changelogithub --draft
+        continue-on-error: ${{ github.event_name == 'workflow_dispatch' }}
         env:
+          RELEASE_TAG: ${{ inputs.tag || github.ref_name }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [[ "$RELEASE_TAG" != v* ]]; then
+            echo "Skipping changelog: '$RELEASE_TAG' is not a version tag"
+            exit 0
+          fi
+          pnpm dlx changelogithub --draft --to "$RELEASE_TAG"
 
       - name: Publish npm
         # Trusted publisher OIDC — do not set NODE_AUTH_TOKEN / NPM_TOKEN.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`changelogithub` uses HEAD as the GitHub release ref. Dispatching Release from `dev` made it look up a tag named `dev` and fail before npm/JSR.

Pass `--to` with the `v*` tag (from the dispatch input or the tag-push ref). Dispatch changelog failures do not block publish.

## Test plan

- [ ] Tag `v2.2.0` Release: changelog uses `--to v2.2.0`, npm skip, JSR publishes

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e3a09f8e-dce8-48a8-bbcd-2534ae4eaeea?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e3a09f8e-dce8-48a8-bbcd-2534ae4eaeea&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

